### PR TITLE
Disable continuous spell checking in Safari.

### DIFF
--- a/.osx
+++ b/.osx
@@ -483,6 +483,9 @@ defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebK
 # Add a context menu item for showing the Web Inspector in web views
 defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
 
+# Disable continuous spell checking in Safari
+defaults write com.apple.Safari WebContinuousSpellCheckingEnabled -bool false
+
 ###############################################################################
 # Mail                                                                        #
 ###############################################################################


### PR DESCRIPTION
Useful to have:

+ `defaults write com.apple.Safari WebContinuousSpellCheckingEnabled -bool false`